### PR TITLE
トークン保存処理 / 仮ログアウトボタン / 仮初回ローディング表示を追加

### DIFF
--- a/src/actions/auth.js
+++ b/src/actions/auth.js
@@ -1,5 +1,7 @@
 import TogglAPIClient from '../helpers/TogglAPIClient';
+import storageUtils from '../helpers/storageUtils';
 import * as types from '../constants/authActionTypes';
+import {AUTH_TOKEN_KEY} from '../constants/storage';
 
 /**
  * APIToken リクエストを実行
@@ -31,6 +33,19 @@ export function login(userData) {
   };
 }
 
+
+/**
+ * ログアウトを実行
+ *
+ * @return {function}
+ */
+export function logout() {
+  return dispatch => {
+    dispatch(removeToken());
+    return dispatch({type: types.LOGOUT});
+  };
+}
+
 /**
  * APIToken リクエスト完了時の処理
  *
@@ -48,4 +63,61 @@ export function receiveToken(client) {
  */
 export function requestToken() {
   return {type: types.REQUEST_TOKEN};
+}
+
+
+/**
+ * Auth Token をストレージから取得する ActionCreator
+ *
+ * @return {Object}
+ */
+export function restoreToken() {
+  const promise = storageUtils.getItem(AUTH_TOKEN_KEY);
+  return {type: types.RESTORE_TOKEN, payload: promise};
+}
+
+
+/**
+ * AuthToken を Storage に保存する ActionCreator
+ *
+ * @param {string} token Auth Token
+ * @return {Object}
+ */
+export function saveToken(token) {
+  const promise = storageUtils.setItem(AUTH_TOKEN_KEY, token);
+  return {type: types.SAVE_TOKEN, payload: promise};
+}
+
+
+/**
+ * AuthToken の保存の必要がある場合に Storage に保存する ActionCreator
+ *
+ * 以下の条件のいずれかに合致した場合のみ保存する
+ *
+ * - AuthToken が Storage に保存されていない
+ * - AuthToken が Storage に保存されているものと異なる
+ *
+ * @param {string} token auth token
+ * @return {function}
+ */
+export function saveTokenIfNeeded(token) {
+  return dispatch => {
+    storageUtils.getItem(AUTH_TOKEN_KEY)
+      .then(oldToken => {
+        if (oldToken !== token) {
+          dispatch(saveToken(token));
+        }
+      });
+  };
+}
+
+
+/**
+ * AuthToken を Storage から削除する ActionCreator
+ *
+ * @return {Object}
+ */
+export function removeToken() {
+  const promise = storageUtils.removeItem(AUTH_TOKEN_KEY);
+  return {type: types.REMOVE_TOKEN, payload: promise};
 }

--- a/src/constants/authActionTypes.js
+++ b/src/constants/authActionTypes.js
@@ -2,5 +2,9 @@ import uniqueActionTypes from '../helpers/uniqueActionTypes';
 
 
 export default uniqueActionTypes('AUTH/', [
-  'REQUEST_TOKEN', 'RECEIVE_TOKEN'
+  'LOGOUT',
+  'REQUEST_TOKEN',
+  'RECEIVE_TOKEN',
+  'REMOVE_TOKEN',
+  'RESTORE_TOKEN'
 ]);

--- a/src/constants/storage.js
+++ b/src/constants/storage.js
@@ -1,0 +1,1 @@
+export const AUTH_TOKEN_KEY = 'koshian/authToken';

--- a/src/containers/App.js
+++ b/src/containers/App.js
@@ -3,7 +3,12 @@ import {connect} from 'react-redux/native';
 import LoginPage from './LoginPage';
 import IndexPage from './IndexPage';
 
-const {StatusBarIOS} = React;
+import {
+  restoreToken,
+  saveTokenIfNeeded
+} from '../actions/auth';
+
+const {StatusBarIOS, View, Text} = React;
 
 
 class App extends React.Component {
@@ -14,7 +19,15 @@ class App extends React.Component {
   }
 
   componentDidMount() {
+    this.props.dispatch(restoreToken());
     StatusBarIOS.setHidden(true);
+  }
+
+  componentWillReceiveProps(nextProps) {
+    // client がセットされたタイミングで必要があれば AuthToken をストレージに保存
+    if (this.props.auth.client === null && nextProps.auth.client !== null) {
+      this.props.dispatch(saveTokenIfNeeded(nextProps.auth.client.apiToken));
+    }
   }
 
   /**
@@ -23,10 +36,17 @@ class App extends React.Component {
    * @return {ReactElement}
    */
   render() {
-    if (this.props.auth.client === null) {
-      return <LoginPage />;
+    if (!this.props.auth.isRestored) {
+      // FIXME: ちゃんとしたローディングページを
+      return (
+        <View>
+          <Text>Initializing...</Text>
+        </View>
+      );
+    } else if (this.props.auth.client) {
+      return <IndexPage />;
     }
-    return <IndexPage />;
+    return <LoginPage />;
   }
 }
 

--- a/src/containers/IndexPage.js
+++ b/src/containers/IndexPage.js
@@ -1,5 +1,6 @@
 import React from 'react-native';
 import {connect} from 'react-redux/native';
+import {logout} from '../actions/auth';
 import {
   changePeriodViewIndex,
   changeViewPeriod,
@@ -8,7 +9,7 @@ import {
 import TimerFormView from './TimerFormView';
 import PeriodScrollView from '../components/PeriodScrollView';
 
-const {View} = React;
+const {View, Text} = React;
 
 
 class IndexPage extends React.Component {
@@ -22,6 +23,21 @@ class IndexPage extends React.Component {
     this.props.dispatch(initializePeriodViewIndex(this.props.period.currentDate));
   }
 
+  onPressLogoutBtn = () => {
+    this.props.dispatch(logout());
+  }
+
+  /**
+   * FIXME: 仮ログアウトボタンをレンダリング
+   *
+   * @return {ReactElement}
+   */
+  renderLogoutBtn() {
+    return (
+      <Text onPress={this.onPressLogoutBtn}>Logout</Text>
+    );
+  }
+
   /**
    * レンダリング
    *
@@ -30,6 +46,7 @@ class IndexPage extends React.Component {
   render() {
     return (
       <View>
+        {this.renderLogoutBtn()}
         <PeriodScrollView
           changePeriodViewIndex={changePeriodViewIndex}
           changeViewPeriod={changeViewPeriod}

--- a/src/helpers/storageUtils.js
+++ b/src/helpers/storageUtils.js
@@ -1,0 +1,38 @@
+import {AsyncStorage} from 'react-native';
+
+
+/**
+ * AsyncStora.getItem
+ *
+ * @param {string} key キー
+ * @return {Promise}
+ */
+export function getItem(key) {
+  return AsyncStorage.getItem(key);
+}
+
+
+/**
+ * AsyncStora.removeItem
+ *
+ * @param {string} key キー
+ * @return {Promise}
+ */
+export function removeItem(key) {
+  return AsyncStorage.removeItem(key);
+}
+
+
+/**
+ * AsyncStora.setItem
+ *
+ * @param {string} key キー
+ * @param {string} value 値
+ * @return {Promise}
+ */
+export function setItem(key, value) {
+  return AsyncStorage.setItem(key, value);
+}
+
+
+export default {getItem, removeItem, setItem};

--- a/src/reducers/auth.js
+++ b/src/reducers/auth.js
@@ -1,6 +1,8 @@
 import TogglAPIClient from '../helpers/TogglAPIClient';
 import {
+  LOGOUT,
   RECEIVE_TOKEN,
+  RESTORE_TOKEN,
   REQUEST_TOKEN
 } from '../constants/authActionTypes';
 
@@ -14,9 +16,12 @@ import {
  */
 export function auth(state = {
   client: null,
-  isConnecting: false
+  isConnecting: false,
+  isRestored: false
 }, action) {
   switch (action.type) {
+  case LOGOUT:
+    return Object.assign({}, state, {client: null});
   case RECEIVE_TOKEN:
     if (action.error) {
       console.error(action.payload);
@@ -37,7 +42,29 @@ export function auth(state = {
       state,
       {isConnecting: true}
     );
+  case RESTORE_TOKEN:
+    return restoreToken(state, action);
   default:
     return state;
   }
+}
+
+
+/**
+ * ストレージから AuthToken 取得時完了時の処理
+ *
+ * @param {Object} state state
+ * @param {Object} action action
+ * @return {Object}
+ */
+export function restoreToken(state, action) {
+  if (action.error) {
+    console.error(action.payload);
+    return state;
+  }
+  const newState = {isRestored: true};
+  if (action.payload) {
+    newState.client = new TogglAPIClient(action.payload);
+  }
+  return Object.assign({}, state, newState);
 }

--- a/test/actions/auth-spec.js
+++ b/test/actions/auth-spec.js
@@ -1,13 +1,25 @@
 import assert from 'power-assert';
+import proxyquire from 'proxyquire';
 
-import * as login from '../../src/actions/auth';
 import * as types from '../../src/constants/authActionTypes';
 
 
 describe('actions/auth', () => {
+  let actions = null;
+
+  beforeEach(() => {
+    actions = proxyquire('../../src/actions/auth', {
+      '../helpers/storageUtils': {
+        getItem: () => {},
+        setItem: () => {},
+        '@noCallThru': true
+      }
+    });
+  });
+
   describe('receiveToken', () => {
     it('apiClient の戻り値を受け取って payload に入れる', () => {
-      const action = login.receiveToken('dummy');
+      const action = actions.receiveToken('dummy');
       assert.deepEqual(action, {
         type: types.RECEIVE_TOKEN,
         payload: 'dummy'


### PR DESCRIPTION
- AsyncStorage を使用した Token 取得 / 保存
- IndexPage の最上部に Text のみのログアウトボタンをとりあえず設置
  - (場所適当に直したげて)
- Storage からトークンを取得するまで App で仮のローディングViewを表示
