### PR TITLE
Flow導入 / React-Native v0.13 Update

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -26,7 +26,33 @@
 # Ignore Website
 .*/website/.*
 
+.*/node_modules/react/.*
+.*/node_modules/react-redux/node_modules/invariant/.*
+.*/node_modules/babel/.*
+.*/node_modules/babel-eslint/.*
+.*/node_modules/babel-plugin-espower/.*
+.*/node_modules/babel-runtime/.*
+.*/node_modules/base64util/.*
+.*/node_modules/codecov.io/.*
+.*/node_modules/esdoc/.*
+.*/node_modules/esdoc-es7-plugin/.*
+.*/node_modules/eslint/.*
+.*/node_modules/eslint-config-kanmu/.*
+.*/node_modules/eslint-plugin-react/.*
+.*/node_modules/isparta/.*
+.*/node_modules/mocha/.*
+.*/node_modules/npm-run-all/.*
+.*/node_modules/power-assert/.*
+.*/node_modules/proxyquire/.*
+.*/node_modules/react-addons-test-utils/.*
+.*/node_modules/react-shallow-testutils/.*
+.*/node_modules/sinon/.*
+.*/node_modules/superagent/.*
+.*/node_modules/watch/.*
+
 [include]
+.*/node_modules/react/.*
+.*/src/.*
 
 [libs]
 node_modules/react-native/Libraries/react-native/react-native-interface.js
@@ -43,9 +69,9 @@ suppress_type=$FlowIssue
 suppress_type=$FlowFixMe
 suppress_type=$FixMe
 
-suppress_comment=\\(.\\|\n\\)*\\$FlowFixMe\\($\\|[^(]\\|(\\(>=0\\.\\(1[0-6]\\|[0-9]\\).[0-9]\\)? *\\(site=[a-z,_]*react_native[a-z,_]*\\)?)\\)
-suppress_comment=\\(.\\|\n\\)*\\$FlowIssue\\((\\(>=0\\.\\(1[0-6]\\|[0-9]\\).[0-9]\\)? *\\(site=[a-z,_]*react_native[a-z,_]*\\)?)\\)? #[0-9]+
+suppress_comment=\\(.\\|\n\\)*\\$FlowFixMe\\($\\|[^(]\\|(\\(>=0\\.\\(1[0-7]\\|[0-9]\\).[0-9]\\)? *\\(site=[a-z,_]*react_native[a-z,_]*\\)?)\\)
+suppress_comment=\\(.\\|\n\\)*\\$FlowIssue\\((\\(>=0\\.\\(1[0-7]\\|[0-9]\\).[0-9]\\)? *\\(site=[a-z,_]*react_native[a-z,_]*\\)?)\\)? #[0-9]+
 suppress_comment=\\(.\\|\n\\)*\\$FlowFixedInNextDeploy
 
 [version]
-0.16.0
+0.17.0

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "eslint": "^1.7.1",
     "eslint-config-kanmu": "^7.0.0",
     "eslint-plugin-react": "^3.6.2",
+    "flow-bin": "^0.17.0",
     "isparta": "^3.1.0",
     "mocha": "^2.3.3",
     "nock": "^2.15.0",
@@ -23,7 +24,8 @@
     "react": "^0.14.0",
     "react-addons-test-utils": "^0.14.0",
     "react-shallow-testutils": "^0.6.0",
-    "sinon": "^1.17.1"
+    "sinon": "^1.17.1",
+    "watch": "^0.16.0"
   },
   "dependencies": {
     "base64util": "^1.0.0",
@@ -47,6 +49,7 @@
     "clean": "rm -rf {dist,coverage}",
     "codecov": "cat coverage/lcov.info | codecov",
     "doc": "esdoc -c esdoc.json",
+    "stop-flow": "flow stop",
     "lint": "eslint {src,test}",
     "packager": "node_modules/react-native/packager/packager.sh",
     "prepackager": "npm run build",
@@ -57,6 +60,7 @@
     "test": "npm-run-all lint test:*",
     "test:coverage": "babel-node $(npm bin)/isparta cover --report text --report html --report lcovonly _mocha -- test/**/*spec.js",
     "watch": "npm-run-all --parallel watch:*",
+    "watch:flow": "watch flow src/",
     "watch:src": "babel --out-dir dist --watch src",
     "watch:test": "mocha --watch test/**/*spec.js"
   }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "base64util": "^1.0.0",
     "moment": "^2.10.6",
-    "react-native": "^0.11.4",
+    "react-native": "^0.13.1",
     "react-redux": "^3.1.0",
     "redux": "^3.0.2",
     "redux-logger": "^2.0.4",

--- a/src/actions/auth.js
+++ b/src/actions/auth.js
@@ -1,7 +1,18 @@
+/* @flow */
 import TogglAPIClient from '../helpers/TogglAPIClient';
 import storageUtils from '../helpers/storageUtils';
-import * as types from '../constants/authActionTypes';
+import types from '../constants/authActionTypes';
 import {AUTH_TOKEN_KEY} from '../constants/storage';
+
+type Action = {
+  type: string,
+  payload: any,
+}
+type UserData = {
+  username: string,
+  password: string
+};
+
 
 /**
  * APIToken リクエストを実行
@@ -11,7 +22,7 @@ import {AUTH_TOKEN_KEY} from '../constants/storage';
  * @param {string} userData.password password
  * @return {function}
  */
-function getToken(userData) {
+function getToken(userData: UserData): Function {
   return dispatch => {
     const promise = TogglAPIClient.login(userData.username, userData.password);
     dispatch(requestToken());
@@ -27,7 +38,7 @@ function getToken(userData) {
  * @param {string} userData.password password
  * @return {function}
  */
-export function login(userData) {
+export function login(userData: UserData): Function {
   return dispatch => {
     return dispatch(getToken(userData));
   };
@@ -39,7 +50,7 @@ export function login(userData) {
  *
  * @return {function}
  */
-export function logout() {
+export function logout(): Function {
   return dispatch => {
     dispatch(removeToken());
     return dispatch({type: types.LOGOUT});
@@ -52,7 +63,7 @@ export function logout() {
  * @param {Promise} client TogglAPIClient.login の戻り値
  * @return {Object} action
  */
-export function receiveToken(client) {
+export function receiveToken(client): Action {
   return {type: types.RECEIVE_TOKEN, payload: client};
 }
 
@@ -61,7 +72,7 @@ export function receiveToken(client) {
  *
  * @return {Object} action
  */
-export function requestToken() {
+export function requestToken(): {type: string} {
   return {type: types.REQUEST_TOKEN};
 }
 
@@ -71,7 +82,7 @@ export function requestToken() {
  *
  * @return {Object}
  */
-export function restoreToken() {
+export function restoreToken(): Action {
   const promise = storageUtils.getItem(AUTH_TOKEN_KEY);
   return {type: types.RESTORE_TOKEN, payload: promise};
 }
@@ -83,7 +94,7 @@ export function restoreToken() {
  * @param {string} token Auth Token
  * @return {Object}
  */
-export function saveToken(token) {
+export function saveToken(token: string): Action {
   const promise = storageUtils.setItem(AUTH_TOKEN_KEY, token);
   return {type: types.SAVE_TOKEN, payload: promise};
 }
@@ -100,7 +111,7 @@ export function saveToken(token) {
  * @param {string} token auth token
  * @return {function}
  */
-export function saveTokenIfNeeded(token) {
+export function saveTokenIfNeeded(token: string): Function {
   return dispatch => {
     storageUtils.getItem(AUTH_TOKEN_KEY)
       .then(oldToken => {
@@ -117,7 +128,7 @@ export function saveTokenIfNeeded(token) {
  *
  * @return {Object}
  */
-export function removeToken() {
+export function removeToken(): Action {
   const promise = storageUtils.removeItem(AUTH_TOKEN_KEY);
   return {type: types.REMOVE_TOKEN, payload: promise};
 }

--- a/src/actions/period.js
+++ b/src/actions/period.js
@@ -1,10 +1,12 @@
-import {
-  CHANGE_PERIOD_VIEW_INDEX,
-  CHANGE_VIEW_PERIOD,
-  INITIALIZE_PERIOD_VIEW_INDEX,
-  RESPONSE_PERIOD_TIME_ENTRIES
-} from '../constants/period';
+/* @flow */
+import types from '../constants/period';
 import {getPeriodDates} from '../helpers/dateUtils';
+
+type Action = {
+  type: string,
+  payload: any
+};
+
 
 /**
  * PeriodScrollView の表示中の index を変更
@@ -12,9 +14,9 @@ import {getPeriodDates} from '../helpers/dateUtils';
  * @param {number} index index
  * @return {Object}
  */
-export function changePeriodViewIndex(index) {
+export function changePeriodViewIndex(index: number): Action {
   return {
-    type: CHANGE_PERIOD_VIEW_INDEX,
+    type: types.CHANGE_PERIOD_VIEW_INDEX,
     payload: {index}
   };
 }
@@ -25,9 +27,9 @@ export function changePeriodViewIndex(index) {
  * @param {string} direction direction
  * @return {Object}
  */
-export function changeViewPeriod(direction) {
+export function changeViewPeriod(direction: string): Action {
   return {
-    type: CHANGE_VIEW_PERIOD,
+    type: types.CHANGE_VIEW_PERIOD,
     payload: {direction}
   };
 }
@@ -39,13 +41,21 @@ export function changeViewPeriod(direction) {
  * @param {Date} currentDate 現在表示対象の日時
  * @return {Object}
  */
-export function initializePeriodViewIndex(currentDate) {
+export function initializePeriodViewIndex(currentDate: Date): {
+  type: string,
+  meta: {
+    client: {
+      type: string,
+      next: Function
+    }
+  }
+} {
   const [start, end] = getPeriodDates(currentDate, 1);
   return {
-    type: INITIALIZE_PERIOD_VIEW_INDEX,
+    type: types.INITIALIZE_PERIOD_VIEW_INDEX,
     meta: {
       client: {
-        type: RESPONSE_PERIOD_TIME_ENTRIES,
+        type: types.RESPONSE_PERIOD_TIME_ENTRIES,
         next: client => client.getTimeEntries(start, end)
       }
     }

--- a/src/constants/authActionTypes.js
+++ b/src/constants/authActionTypes.js
@@ -1,3 +1,4 @@
+/* @flow */
 import uniqueActionTypes from '../helpers/uniqueActionTypes';
 
 

--- a/src/constants/period.js
+++ b/src/constants/period.js
@@ -1,3 +1,4 @@
+/* @flow */
 import uniqueActionTypes from '../helpers/uniqueActionTypes';
 
 

--- a/src/helpers/dateUtils.js
+++ b/src/helpers/dateUtils.js
@@ -1,3 +1,4 @@
+/* @flow */
 import moment from 'moment';
 
 
@@ -10,7 +11,7 @@ import moment from 'moment';
  * @param {number} [duration] 間隔
  * @return {Date[]}
  */
-export function getPeriodDates(currentDate, duration = 1) {
+export function getPeriodDates(currentDate: Date, duration: number = 1): Date[] {
   const start = moment(currentDate).startOf('day');
   const end = start.clone().add(duration, 'd');
   return [start.toDate(), end.toDate()];
@@ -23,6 +24,6 @@ export function getPeriodDates(currentDate, duration = 1) {
  * @param {Date|string} date 対象日時
  * @return {string}
  */
-export function createTimeEntryKey(date) {
+export function createTimeEntryKey(date: (Date|string)): string {
   return moment(date).format('YYYYMMDD');
 }

--- a/src/helpers/storageUtils.js
+++ b/src/helpers/storageUtils.js
@@ -1,3 +1,4 @@
+/* @flow */
 import {AsyncStorage} from 'react-native';
 
 
@@ -7,7 +8,7 @@ import {AsyncStorage} from 'react-native';
  * @param {string} key キー
  * @return {Promise}
  */
-export function getItem(key) {
+export function getItem(key: string): Promise {
   return AsyncStorage.getItem(key);
 }
 
@@ -18,7 +19,7 @@ export function getItem(key) {
  * @param {string} key キー
  * @return {Promise}
  */
-export function removeItem(key) {
+export function removeItem(key: string): Promise {
   return AsyncStorage.removeItem(key);
 }
 
@@ -30,7 +31,7 @@ export function removeItem(key) {
  * @param {string} value 値
  * @return {Promise}
  */
-export function setItem(key, value) {
+export function setItem(key: string, value: string): Promise {
   return AsyncStorage.setItem(key, value);
 }
 

--- a/src/helpers/uniqueActionTypes.js
+++ b/src/helpers/uniqueActionTypes.js
@@ -1,3 +1,4 @@
+/* @flow */
 const registeredKeys = [];
 
 /**
@@ -7,7 +8,9 @@ const registeredKeys = [];
  * @param {string[]} actionTypes action type 名リスト
  * @return {Object}
  */
-export default function uniqueActionTypes(prefix, actionTypes) {
+export default function uniqueActionTypes(prefix: string, actionTypes: Array<string>): {
+  [key: string]: string
+} {
   const ret = {};
   actionTypes.forEach(type => {
     const key = `${prefix}${type}`;

--- a/src/middlewares/client.js
+++ b/src/middlewares/client.js
@@ -2,6 +2,7 @@
 /**
  * API クライアント実行ミドルウェア
  *
+ * @param {function} dispatch dispatch
  * @param {function} getState getState
  * @return {function}
  */

--- a/src/middlewares/client.js
+++ b/src/middlewares/client.js
@@ -1,10 +1,14 @@
+/* @flow */
 /**
  * API クライアント実行ミドルウェア
  *
  * @param {function} getState getState
  * @return {function}
  */
-export default function clientMiddleware({dispatch, getState}) {
+export default function clientMiddleware({dispatch, getState}: {
+  dispatch: Function,
+  getState: Function
+}): Function {
   return next => action => {
     const state = getState();
     if (action.meta && action.meta.client) {

--- a/src/reducers/auth.js
+++ b/src/reducers/auth.js
@@ -1,10 +1,16 @@
+/* @flow */
 import TogglAPIClient from '../helpers/TogglAPIClient';
-import {
-  LOGOUT,
-  RECEIVE_TOKEN,
-  RESTORE_TOKEN,
-  REQUEST_TOKEN
-} from '../constants/authActionTypes';
+import types from '../constants/authActionTypes';
+
+type Action = {
+  type: string,
+  payload: Object
+};
+type State = {
+  client: TogglAPIClient,
+  isConnecting: boolean,
+  isRestored: boolean
+};
 
 
 /**
@@ -14,15 +20,15 @@ import {
  * @param {Object} action action
  * @return {Object} state
  */
-export function auth(state = {
+export function auth(state: State = {
   client: null,
   isConnecting: false,
   isRestored: false
-}, action) {
+}, action: Action): State {
   switch (action.type) {
-  case LOGOUT:
+  case types.LOGOUT:
     return Object.assign({}, state, {client: null});
-  case RECEIVE_TOKEN:
+  case types.RECEIVE_TOKEN:
     if (action.error) {
       console.error(action.payload);
       break;
@@ -36,13 +42,13 @@ export function auth(state = {
         isConnecting: false
       }
     );
-  case REQUEST_TOKEN:
+  case types.REQUEST_TOKEN:
     return Object.assign(
       {},
       state,
       {isConnecting: true}
     );
-  case RESTORE_TOKEN:
+  case types.RESTORE_TOKEN:
     return restoreToken(state, action);
   default:
     return state;
@@ -57,12 +63,12 @@ export function auth(state = {
  * @param {Object} action action
  * @return {Object}
  */
-export function restoreToken(state, action) {
+export function restoreToken(state: State, action: Action): State {
   if (action.error) {
     console.error(action.payload);
     return state;
   }
-  const newState = {isRestored: true};
+  const newState: Object = {isRestored: true};
   if (action.payload) {
     newState.client = new TogglAPIClient(action.payload);
   }


### PR DESCRIPTION
- Flow を component 以外に適用
  - `helpers/TogglAPIClient` のみ class の computed property への型指定エラーを解決できなかったので一旦除外
- `npm i` -> `npm start` で Flow による型チェックを開始する
  - 裏で flow server が走り続ける。必要に応じて `npm run stop-flow` で sever を停止すること
  - `git rebase` など大きくコードを変更する前に停止しておかないと高負荷で死ぬ可能性あり
