### PR TITLE
chore(scripts): Replace watch to chokidar

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "babel-eslint": "^4.1.3",
     "babel-plugin-espower": "^1.0.0",
     "babel-runtime": "^5.8.25",
+    "chokidar-cli": "^1.1.1",
     "clear-require": "^1.0.1",
     "codecov.io": "^0.1.6",
     "esdoc": "^0.4.1",
@@ -25,8 +26,7 @@
     "react": "^0.14.0",
     "react-addons-test-utils": "^0.14.0",
     "react-shallow-testutils": "^0.6.0",
-    "sinon": "^1.17.1",
-    "watch": "^0.16.0"
+    "sinon": "^1.17.1"
   },
   "dependencies": {
     "base64util": "^1.0.0",
@@ -62,7 +62,7 @@
     "test": "npm-run-all lint test:*",
     "test:coverage": "babel-node $(npm bin)/isparta cover --report text --report html --report lcovonly _mocha -- test/**/*spec.js",
     "watch": "npm-run-all --parallel watch:*",
-    "watch:flow": "watch flow src/",
+    "watch:flow": "flow & chokidar src/ -c flow",
     "watch:src": "babel --out-dir dist --watch src",
     "watch:test": "mocha --watch test/**/*spec.js"
   }


### PR DESCRIPTION
- ファイル変更の監視ライブラリを chokidar にした
- watch より chokidar のほうが反応が早いので快適
- ref: [橋本商会 » chokidar-cliのファイル更新監視が速い](http://shokai.org/blog/archives/10194)
